### PR TITLE
Start using PMVector and cleaning

### DIFF
--- a/src/AI-EditDistances-Tests/AIHellingerDistanceTest.class.st
+++ b/src/AI-EditDistances-Tests/AIHellingerDistanceTest.class.st
@@ -27,39 +27,51 @@ AIHellingerDistanceTest >> setUp [
 ]
 
 { #category : #tests }
-AIHellingerDistanceTest >> testDifferentDistributions [
+AIHellingerDistanceTest >> testDifferentDistribution1 [
 
-    | p q |
-
-    p := #(0.36 0.48 0.16).
-    q := #(0.33 0.33 0.33).
-    self
-		assert: (metric distanceBetween: p and: q) 
+	| p q |
+	p := #( 0.36 0.48 0.16 ).
+	q := #( 0.33 0.33 0.33 ).
+	self
+		assert: (metric distanceBetween: p and: q)
 		closeTo: 0.15049826726881443
-		epsilon: 0.001.
+		epsilon: 0.001
+]
 
-    p := #(0.25 0.25 0.25 0.25).
-    q := #(0.1 0.2 0.3 0.4).
-    self 	
-		assert: (metric distanceBetween: p and: q) 
-		closeTo: 0.167 
-		epsilon: 0.001.
+{ #category : #tests }
+AIHellingerDistanceTest >> testDifferentDistribution2 [
 
-    p := #(0 0.5 0.5).
-    q := #(1 0 0).
-    self 	
-		assert: (metric distanceBetween: p and: q) 
+	| p q |
+	p := #( 0.25 0.25 0.25 0.25 ).
+	q := #( 0.1 0.2 0.3 0.4 ).
+	self
+		assert: (metric distanceBetween: p and: q)
+		closeTo: 0.167
+		epsilon: 0.001
+]
+
+{ #category : #tests }
+AIHellingerDistanceTest >> testDifferentDistribution3 [
+
+	| p q |
+	p := #( 0 0.5 0.5 ).
+	q := #( 1 0 0 ).
+	self
+		assert: (metric distanceBetween: p and: q)
 		closeTo: 1.0
-		epsilon: 0.0001.
+		epsilon: 0.0001
+]
 
-    p := #(0.2 0.3 0.1 0.4).
-    q := #(0.1 0.4 0.3 0.2).
-    self 	
-		assert: (metric distanceBetween: p and: q) 
+{ #category : #tests }
+AIHellingerDistanceTest >> testDifferentDistribution4 [
+
+	| p q |
+	p := #( 0.2 0.3 0.1 0.4 ).
+	q := #( 0.1 0.4 0.3 0.2 ).
+	self
+		assert: (metric distanceBetween: p and: q)
 		closeTo: 0.2368980623511251
-		epsilon: 0.0001.
-
-
+		epsilon: 0.0001
 ]
 
 { #category : #tests }

--- a/src/AI-EditDistances/AIEuclideanDistance.class.st
+++ b/src/AI-EditDistances/AIEuclideanDistance.class.st
@@ -11,16 +11,7 @@ Class {
 
 { #category : #api }
 AIEuclideanDistance >> distanceBetween: firstPoint and: secondPoint [
+	"It follows the Euclidean distance between two points formula"
 
-	"It follows the Euclidean distance between two points formula.
-	The code is not idiomatic because of performance. We see that writting this instead of 
-	(firstPoint - secondPoint raisedTo: 2) sum sqrt"
-
-	| sum |
-	sum := 0.0.
-	1 to: firstPoint size do: [ :i | 
-		| diff |
-		diff := (firstPoint at: i) asFloat - (secondPoint at: i) asFloat.
-		sum := sum + (diff * diff) ].
-	^ sum sqrt
+	^ (firstPoint asPMVector - secondPoint asPMVector) norm
 ]

--- a/src/AI-EditDistances/AIHellingerDistance.class.st
+++ b/src/AI-EditDistances/AIHellingerDistance.class.st
@@ -1,18 +1,39 @@
 "
 ## Description
 
-In probability and statistics, the Hellinger distance is used to quantify the similarity between two probability distributions.
+In probability and statistics, the Hellinger distance is used to quantify the similarity between two probability distributions. The Hellinger distance is defined in terms of the Hellinger integral [more info in the wikipedia page](https://en.wikipedia.org/wiki/Hellinger_distance).
+
+The Hellinger distance is defined as:
+
+$H^2(P,Q) = 1/2 \int (\sqrt{P(dx)} - \sqrt{Q(dx)})^{2}$, where P(x) and Q(x) are two probability distribution functions.
+
+We can aproximate its value if we calculate n points of the probaility distrubutions for after summing them. At the end, the integral is just an infite sum.
+
+So the above formula can be implemented as the followuing:
+
+$H(P,Q) = \sqrt {1/2 \sum_{x=0}^{n} (\sqrt{P(x)} - \sqrt{Q(x)})^2}$
+
+If we observe this is the same formula as the one of the integral, except that we approximating the value with the sum of n values of the evaluated probability functions.
+We can take out the $1/2$ of the `sqrt` as $1/\sqrt {2}$ to have the followinf formula:
+
+$H(P,Q) = 1/\sqrt {2} \sqrt {\sum_{x=0}^{n} (\sqrt{P(x)} - \sqrt{Q(x)})^2}$
+
+We can see that $\sqrt {\sum_{x=0}^{n} (\sqrt{P(x)} - \sqrt{Q(x)})^2$ is nothing more than the norm of the vector $\sqrt {P} - \sqrt {Q}$.
+
+So at the end we have:
+
+$H(P,Q) = 1/\sqrt {2} \lVert \sqrt{P} - \sqrt{Q} \rVert$
 
 ## Usage
 
-The following example takes two probability distributions, p and q, as input and returns the Hellinger distance between them. The method iterates over the probability values, calculates the squared difference of the square roots, sums them up, and finally multiplies the square root of the sum by `(1 / (2 sqrt))`.
+The following example takes two probability distributions, p and q, as input and returns the Hellinger distance between them.
 
 ```language=Pharo
 | p q |
 
 p := #(0.36 0.48 0.16).
 q := #(0.33 0.33 0.33).
-AIHellingerDistance distanceBetween: p and: q.
+AIHellingerDistance new distanceBetween: p and: q.
 ```
 "
 Class {
@@ -24,13 +45,6 @@ Class {
 { #category : #api }
 AIHellingerDistance >> distanceBetween: firstCollection and: secondCollection [
 
-    | numberOfElements |
-
-	(numberOfElements := firstCollection size) = secondCollection size
-		ifFalse: [ self error: 'Distributions must have the same size' ].
-
-    ^ (1 / 2 sqrt) * ((1 to: numberOfElements)
-        inject: 0
-        into: [ :sum :i | sum + ((firstCollection at: i) sqrt - (secondCollection at: i) sqrt) squared.
-        ]) sqrt
+	^ (firstCollection asPMVector sqrt - secondCollection asPMVector sqrt)
+		  norm / 2 sqrt
 ]

--- a/src/AI-EditDistances/AIHellingerDistance.class.st
+++ b/src/AI-EditDistances/AIHellingerDistance.class.st
@@ -7,14 +7,14 @@ The Hellinger distance is defined as:
 
 $H^2(P,Q) = 1/2 \int (\sqrt{P(dx)} - \sqrt{Q(dx)})^{2}$, where P(x) and Q(x) are two probability distribution functions.
 
-We can aproximate its value if we calculate n points of the probaility distrubutions for after summing them. At the end, the integral is just an infite sum.
+We can aproximate its value if we calculate n points of the probaility distributions for after summing them. At the end, the integral is just an infite sum.
 
 So the above formula can be implemented as the followuing:
 
 $H(P,Q) = \sqrt {1/2 \sum_{x=0}^{n} (\sqrt{P(x)} - \sqrt{Q(x)})^2}$
 
 If we observe this is the same formula as the one of the integral, except that we approximating the value with the sum of n values of the evaluated probability functions.
-We can take out the $1/2$ of the `sqrt` as $1/\sqrt {2}$ to have the followinf formula:
+We can take out the $1/2$ of the `sqrt` as $1/\sqrt {2}$ to have the following formula:
 
 $H(P,Q) = 1/\sqrt {2} \sqrt {\sum_{x=0}^{n} (\sqrt{P(x)} - \sqrt{Q(x)})^2}$
 

--- a/src/AI-EditDistances/AIManhattanDistance.class.st
+++ b/src/AI-EditDistances/AIManhattanDistance.class.st
@@ -1,5 +1,5 @@
 "
-The Manhattan distance is the absoulte sum off all the distances between coordinates.
+The Manhattan distance is defined as the first norm of the difference of two vectors. This is the absoulte sum of the difference of each coordinate.
 
 More info: [Manhattan distance](https://computervision.fandom.com/wiki/Manhattan_distance)
 "
@@ -12,5 +12,5 @@ Class {
 { #category : #api }
 AIManhattanDistance >> distanceBetween: anArray and: anotherArray [
 
-	^ (anArray  - anotherArray ) abs sum 
+	^ (anArray asPMVector - anotherArray asPMVector) firstNorm
 ]

--- a/src/AI-EditDistances/AIMinkowskiDistance.class.st
+++ b/src/AI-EditDistances/AIMinkowskiDistance.class.st
@@ -38,12 +38,10 @@ AIMinkowskiDistance class >> p: anInteger [
 { #category : #api }
 AIMinkowskiDistance >> distanceBetween: firstPoint and: secondPoint [
 
-	| sum |
-	sum := 0.
-	firstPoint with: secondPoint do: [ :x :y |
-		sum := sum + ((x - y) abs raisedTo: p) ].
+	| vector |
+	vector := (firstPoint asPMVector - secondPoint asPMVector) abs raisedTo: p.
 
-	^ sum raisedTo: 1 / p
+	^ vector sum raisedTo: 1 / p
 ]
 
 { #category : #accessing }

--- a/src/BaselineOfAIEditDistances/BaselineOfAIEditDistances.class.st
+++ b/src/BaselineOfAIEditDistances/BaselineOfAIEditDistances.class.st
@@ -11,10 +11,16 @@ Class {
 BaselineOfAIEditDistances >> baseline: spec [
 
 	<baseline>
-	spec for: #common do: [ "Packages"
+	spec for: #common do: [
+		"External dependencies"
+		spec
+    		baseline: 'AIExternalVectorMatrix'
+			with: [ spec repository: 'github://pharo-ai/external-dependencies' ].
+		"Packages"
 		spec
 			package: 'AI-EditDistances';
 			package: 'AI-EditDistances-Tests' with: [ spec requires: #( 'AI-EditDistances' ) ].
+		"Groups"
 		spec
 			group: 'Core' with: #( 'AI-EditDistances' );
 			group: 'Tests' with: #( 'AI-EditDistances-Tests' );

--- a/src/BaselineOfAIEditDistances/BaselineOfAIEditDistances.class.st
+++ b/src/BaselineOfAIEditDistances/BaselineOfAIEditDistances.class.st
@@ -18,7 +18,7 @@ BaselineOfAIEditDistances >> baseline: spec [
 			with: [ spec repository: 'github://pharo-ai/external-dependencies' ].
 		"Packages"
 		spec
-			package: 'AI-EditDistances';
+			package: 'AI-EditDistances' with: [ spec requires: #( 'AIExternalVectorMatrix' ) ];
 			package: 'AI-EditDistances-Tests' with: [ spec requires: #( 'AI-EditDistances' ) ].
 		"Groups"
 		spec


### PR DESCRIPTION
- Added vector-matrix dependencie to the baseline.
- Refactored Euclidean, Hellinger, Mannhattan and Minkowski distances to use the norm of PMVector. Those algos use the norm of the vector to calculate the distance
- Improved class comment of Hellinger distance. Added explanations of why we implemented that way because the original formula has an integral and we didn't implemented like that.
- Separated Hellinger distance test into several tests. One there are 4 tests instead of 1