### PR TITLE
Add Missing Tests for AICosineSimilarityDistanceTest

### DIFF
--- a/src/AI-EditDistances-Tests/AICosineSimilarityDistanceTest.class.st
+++ b/src/AI-EditDistances-Tests/AICosineSimilarityDistanceTest.class.st
@@ -20,3 +20,38 @@ AICosineSimilarityDistanceTest >> testCosineSimilarityDistanceTo [
 
 	self assert: (cosineDistance distanceBetween: #(3 45 7 2) and: #(2 54 13 15)) closeTo: 0.9722842517123499
 ]
+
+{ #category : '*AI-EditDistances-Tests' }
+AICosineSimilarityDistanceTest >> testZeroVectors [
+
+	"Checks that the Cosine Similarity between zero vectors returns 1.0 or is handled gracefully."
+	self should: [ metric distanceBetween: #(0 0 0) and: #(0 0 0) ] raise: Error.
+]
+
+{ #category : '*AI-EditDistances-Tests' }
+AICosineSimilarityDistanceTest >> testIdenticalVectors [
+
+	"Checks that the Cosine Similarity between identical vectors is 1.0."
+	self assert: (cosineDistance distanceBetween: #(1 2 3) and: #(1 2 3)) equals: 1.0
+]
+
+{ #category : '*AI-EditDistances-Tests' }
+AICosineSimilarityDistanceTest >> testOrthogonalVectors [
+
+	"Checks that the Cosine Similarity between orthogonal vectors is 0.0."
+	self assert: (cosineDistance distanceBetween: #(1 0) and: #(0 1)) closeTo: 0.0
+]
+
+{ #category : '*AI-EditDistances-Tests' }
+AICosineSimilarityDistanceTest >> testDifferentLengths [
+
+	"Checks that an error is raised for collections of different lengths."
+	self should: [ cosineDistance distanceBetween: #(1 2) and: #(1 2 3) ] raise: Error
+]
+
+{ #category : '*AI-EditDistances-Tests' }
+AICosineSimilarityDistanceTest >> testNonNumericInputs [
+
+	"Checks that an error is raised for non-numeric inputs."
+	self should: [ cosineDistance distanceBetween: #(1 'a' 3) and: #(1 2 3) ] raise: Error
+]

--- a/src/AI-EditDistances/AICosineSimilarityDistance.class.st
+++ b/src/AI-EditDistances/AICosineSimilarityDistance.class.st
@@ -12,13 +12,12 @@ Class {
 }
 
 { #category : 'api' }
-AICosineSimilarityDistance >> distanceBetween: anArray and: anotherArray [
-	| num size1 size2 |
-
-	num := (anArray * anotherArray) sum.
-	size1 := (anArray * anArray) sum sqrt.
-	size2 := (anotherArray * anotherArray) sum sqrt.
-	
-	^ num / (size1 * size2)
-	
+AICosineSimilarityDistance >> distanceBetween: firstCollection and: secondCollection[
+    | dotProduct normA normB |
+    dotProduct := (firstCollection with: secondCollection collect: [ :a :b | a * b ]) sum.
+    normA := (firstCollection collect: [ :x | x * x ]) sum sqrt.
+    normB := (secondCollection collect: [ :x | x * x ]) sum sqrt.
+    (normA = 0 and: [ normB = 0 ])
+        ifTrue: [ ^ 1.0 ] "Zero vectors are considered identical."
+        ifFalse: [ ^ dotProduct / (normA * normB) ]
 ]

--- a/src/AI-EditDistances/AICosineSimilarityDistance.class.st
+++ b/src/AI-EditDistances/AICosineSimilarityDistance.class.st
@@ -12,8 +12,26 @@ Class {
 }
 
 { #category : 'api' }
+AICosineSimilarityDistance >> distanceBetween: anArray and: anotherArray [
+	| num size1 size2 |
+
+	num := (anArray * anotherArray) sum.
+	size1 := (anArray * anArray) sum sqrt.
+	size2 := (anotherArray * anotherArray) sum sqrt.
+
+	^ num / (size1 * size2)
+
+]
+
+{ #category : 'api' }
 AICosineSimilarityDistance >> distanceBetween: firstCollection and: secondCollection[
     | dotProduct normA normB |
+    firstCollection size = secondCollection size ifFalse: [ 
+        self error: 'Collections must have the same length' ].
+    (firstCollection allSatisfy: [ :x | x isNumber ]) ifFalse: [ 
+        self error: 'First collection contains non-numeric elements' ].
+    (secondCollection allSatisfy: [ :x | x isNumber ]) ifFalse: [ 
+        self error: 'Second collection contains non-numeric elements' ].
     dotProduct := (firstCollection with: secondCollection collect: [ :a :b | a * b ]) sum.
     normA := (firstCollection collect: [ :x | x * x ]) sum sqrt.
     normB := (secondCollection collect: [ :x | x * x ]) sum sqrt.


### PR DESCRIPTION
Added test for 

- Checks that the Cosine Similarity between zero vectors returns 1.0 or is handled gracefully.
- Checks that the Cosine Similarity between identical vectors is 1.0.
- Checks that the Cosine Similarity between orthogonal vectors is 0.0.
- Checks that an error is raised for collections of different lengths.
- Checks that an error is raised for non-numeric inputs.

From AICosineSimilarityDistance.class.st I have removed previous method and added new.
**Why?**
The previous method lacks zero-vector handling (causing division-by-zero errors), uses non-standard array operations (*), and doesn’t validate inputs. The new method is more robust, portable, and includes input validation (length and numeric checks) and zero-vector handling, making it the better choice for reliable cosine similarity computation.